### PR TITLE
Relax pronto version restriction

### DIFF
--- a/pronto-jscs.gemspec
+++ b/pronto-jscs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency('pronto', '~> 0.5.0')
+  spec.add_runtime_dependency('pronto', '~> 0.5')
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'


### PR DESCRIPTION
There isn't really a need to lock to a minor pronto version, and when using many pronto support gems, the chances of updating when one moves to a new minor version of pronto become very small. 
